### PR TITLE
Start weapon system

### DIFF
--- a/dev/lib/entities/bullet.js
+++ b/dev/lib/entities/bullet.js
@@ -1,18 +1,19 @@
 class Bullet extends Entity {
   constructor(config) {
     super();
+    const { parent, angle } = config;
+    this.parent = parent;
+    this.angle = angle;
     this.id = generateId(); // TODO: will need to do something more unique
-    this.gameId = config.gameId;
-    this.parent = config.parent;
-    this.angle = config.angle;
-    this.x = config.x;
-    this.y = config.y;
+    this.gameId = parent.gameId;
     this.width = 10;
     this.height = 10;
-    this.speedX = Math.cos((config.angle / 180) * Math.PI) * config.speedX;
-    this.speedY = Math.sin((config.angle / 180) * Math.PI) * config.speedY;
+    this.x = parent.x + (parent.width  / 2) - (this.width  / 2);
+    this.y = parent.y + (parent.height / 2) - (this.height / 2);
+    this.speedX = Math.cos((this.angle / 180) * Math.PI) * parent.weapon.speed;
+    this.speedY = Math.sin((this.angle / 180) * Math.PI) * parent.weapon.speed;
     this.timer = 0;
-    this.damage = config.damage; // comes from the Player, based on weapon
+    this.damage = parent.weapon.damage; // comes from the Player, based on weapon
     this.toRemove = false;
 
     GAMES[this.gameId].bullets[this.id] = this;
@@ -24,38 +25,43 @@ class Bullet extends Entity {
     }
     super.update();
     const game = GAMES[this.gameId];
-    const enemyIds = ids(game.enemies);
-    // TODO: quadtree
-    for (let id in game.enemies) {
-      let enemy = game.enemies[id];
-      const parentIdString = `${this.parent}`;
-      if (!enemyIds.includes(parentIdString) && Entity.overlaps(this, enemy)) {
-        enemy.hp -= this.damage;
-        if (enemy.hp <= 0) {
-          // enemy removal handled in Enemy class
-          const shooter = game.players[this.parent];
-          if (shooter) {
-            shooter.score += 100;
+
+    // TODO: consider quadtree type structure for collisions
+
+    /* Collisions with enemies */
+    if (this.parent.type != 'enemy') { // No friendly fire
+      for (let id in game.enemies) {
+        let enemy = game.enemies[id];
+        if (Entity.overlaps(this, enemy)) {
+          enemy.hp -= this.damage;
+          if (enemy.hp <= 0) {
+            // enemy removal handled in Enemy class
+            const shooter = game.players[this.parent.id];
+            if (shooter) {
+              shooter.score += 100;
+            }
           }
+          this.toRemove = true;
         }
-        this.toRemove = true;
       }
     }
-    // TODO: quadtree
+
+    /* Collisions with enemies */
     for (let id in game.obstacles) {
       let obstacle = game.obstacles[id];
       if (Entity.overlaps(this, obstacle)) {
         this.toRemove = true;
       }
     }
-    const playerIds = ids(game.players);
-    // TODO: quadtree
-    for (let id in game.players) {
-      let player = game.players[id];
-      // no friendly fire ;)
-      if (!playerIds.includes(this.parent) && Entity.overlaps(this, player)) {
-        player.hp -= this.damage;
-        this.toRemove = true;
+
+    /* Collisions with players */
+    if (this.parent.type != 'player') { // No friendly fire
+      for (let id in game.players) {
+        let player = game.players[id];
+        if (Entity.overlaps(this, player)) {
+          player.hp -= this.damage;
+          this.toRemove = true;
+        }
       }
     }
   }

--- a/dev/lib/entities/bullet.js
+++ b/dev/lib/entities/bullet.js
@@ -46,7 +46,7 @@ class Bullet extends Entity {
       }
     }
 
-    /* Collisions with enemies */
+    /* Collisions with obstacles */
     for (let id in game.obstacles) {
       let obstacle = game.obstacles[id];
       if (Entity.overlaps(this, obstacle)) {

--- a/dev/lib/entities/enemy.js
+++ b/dev/lib/entities/enemy.js
@@ -1,6 +1,7 @@
 class Enemy extends Entity {
   constructor(id, gameId, x) {
     super();
+    this.type = 'enemy';
     this.id = id;
     this.gameId = gameId;
     this.targetId = Player.getRandomPlayer(this.gameId).id;
@@ -14,6 +15,10 @@ class Enemy extends Entity {
     this.hpMax = 30;
     this.damage = 10;
     this.toRemove = false;
+    this.weapon = {
+      damage: 10,
+      speed: 10,
+    };
 
     console.log(`New enemy in game ${gameId}:`, this);
     GAMES[gameId].enemies[this.id] = this;
@@ -113,14 +118,8 @@ class Enemy extends Entity {
   }
   shootBullet(angle) {
     new Bullet({
-      parent: this.id,
-      gameId: this.gameId,
       angle: angle,
-      x: this.x,
-      y: this.y,
-      speedX: 10, // move enemy bullet speed to config?
-      speedY: 10, // move enemy bullet speed to config?
-      damage: this.damage,
+      parent: this,
     });
   }
   getInitPack() {

--- a/dev/lib/entity.js
+++ b/dev/lib/entity.js
@@ -1,64 +1,85 @@
 class Entity {
-  constructor() {
-    this.id = '';
-    this.gameId = '';
-    this.x = 250; //TODO: don't spawn player on obstacle
-    this.y = 250; //TODO: don't spawn player on obstacle
-    this.speedX = 0;
-    this.speedY = 0;
-    // this.lastUpdateTime = new Date().getTime();
-  }
-  update() {
-    this.updatePosition();
-  }
-  updatePosition() {
-    // TODO: https://hackernoon.com/how-to-build-a-multiplayer-browser-game-4a793818c29b
-    // const currentTime = new Date().getTime();
-    // const timeDifference = currentTime - this.lastUpdateTime;
-    // this.x += this.speedX * timeDifference;
-    // this.y += this.speedY * timeDifference;
-    this.x += this.speedX;
-    this.y += this.speedY;
-    // this.lastUpdateTime = currentTime;
-  }
-  // TODO: make static
-  getAngle(point) {
-    const x = -this.x + point.x - 8; // TODO: replace hard-coded canvas margin
-    const y = -this.y + point.y - 8; // TODO: replace hard-coded canvas margin
-    return (Math.atan2(y, x) / Math.PI) * 180;
-  }
-  static overlaps(self, target) {
-    return (
-      self.x < target.x + target.width &&
-      self.x + self.width > target.x &&
-      self.y < target.y + target.height &&
-      self.y + self.height > target.y
-    );
-  }
-  static checkCollisionsWithObstacles(self, x, y) {
-    const entityFutureCoords = {
-      x: x,
-      y: y,
-      width: self.width,
-      height: self.height,
-    };
+    constructor() {
+      this.id = '';
+      this.gameId = '';
+      this.x = 250; //TODO: don't spawn player on obstacle
+      this.y = 250; //TODO: don't spawn player on obstacle
+      this.speedX = 0;
+      this.speedY = 0;
+      // this.lastUpdateTime = new Date().getTime();
+    }
+    update() {
+      this.updatePosition();
+    }
+    updatePosition() {
+      // TODO: https://hackernoon.com/how-to-build-a-multiplayer-browser-game-4a793818c29b
+      // const currentTime = new Date().getTime();
+      // const timeDifference = currentTime - this.lastUpdateTime;
+      // this.x += this.speedX * timeDifference;
+      // this.y += this.speedY * timeDifference;
+      this.x += this.speedX;
+      this.y += this.speedY;
+      // this.lastUpdateTime = currentTime;
+    }
+    // TODO: make static
+    getAngle(pointOrEntity) {
+      // We always want the angle from our center
+      const selfX = this.x + this.width / 2;
+      const selfY = this.y + this.height / 2;
 
-    // TODO: only check obstacles in the same quadtree or grid area as player
-    const game = GAMES[self.gameId];
-    for (let i in game.obstacles) {
-      const obstacle = game.obstacles[i];
-      const obstacleFutureCoords = {
-        x: obstacle.x,
-        y: obstacle.y + obstacle.speedY,
-        width: obstacle.width,
-        height: obstacle.height,
-      };
-      if (Entity.overlaps(entityFutureCoords, obstacleFutureCoords)) {
-        return obstacle;
+      // For points, we want to get the direct angle (e.g. player shooting at mouse point)
+      // But for entities, we want to get the center (e.g. enemy shooting at player)
+      let targetX = pointOrEntity.x;
+      let targetY = pointOrEntity.y;
+      if (pointOrEntity.width && pointOrEntity.height) {
+        targetX += pointOrEntity.width / 2;
+        targetY += pointOrEntity.height / 2;
+      }
+
+      const x = -selfX + targetX - 8; // TODO: replace hard-coded canvas margin
+      const y = -selfY + targetY - 8; // TODO: replace hard-coded canvas margin
+      return (Math.atan2(y, x) / Math.PI) * 180;
+    }
+    static overlaps(self, target) {
+      return (
+        self.x < target.x + target.width &&
+        self.x + self.width > target.x &&
+        self.y < target.y + target.height &&
+        self.y + self.height > target.y
+      );
+    }
+    static getAllInitPack(gameId, entityType) {
+      const existingEntities = [];
+      const game = GAMES[gameId];
+      for (let id in game[entityType]) {
+        const entity = game[entityType][id];
+        existingEntities.push(entity.getInitPack());
       }
     }
-    return false;
-  }
+    static checkCollisionsWithObstacles(self, x, y) {
+      const entityFutureCoords = {
+        x: x,
+        y: y,
+        width: self.width,
+        height: self.height,
+      };
+
+      // TODO: only check obstacles in the same quadtree or grid area as player
+      const game = GAMES[self.gameId];
+      for (let i in game.obstacles) {
+        const obstacle = game.obstacles[i];
+        const obstacleFutureCoords = {
+          x: obstacle.x,
+          y: obstacle.y + obstacle.speedY,
+          width: obstacle.width,
+          height: obstacle.height,
+        };
+        if (Entity.overlaps(entityFutureCoords, obstacleFutureCoords)) {
+          return obstacle;
+        }
+      }
+      return false;
+    }
   static getAllInitPack(gameId, entityType) {
     const existingEntities = [];
     const game = GAMES[gameId];


### PR DESCRIPTION
ref(*): abstract weapons, offset angles, simplify collisions
    
This commit

* abstracts bullet speed, damage, etc. into a weapon object. E.g.,
player.damage -> player.weapon.damage, etc.
* abstracts player shooting cool down into said weapon object + new method
* replaces bullet config with parent reference. Now bullets can derive all
 their info from the shooter
* offsets angles and shooting from entity centers (rather than upper left
    corner). This also updates the getAngle method to be accept either points
    or Entities
* add a 'type' property to enemies and players, which lets us skip lots
    of collision calculations in bullets. Instead of checking each object
    in the game, and then looping through all available players/enemies to
    confirm an ID, we instead only check for collisions on the appropriate
    types - player bullets look for enemy collisions, enemy bullets look for
    player collisions