### PR TITLE
feat(*): weapons, dropables, and improved weapon systems

### DIFF
--- a/dev/client.js
+++ b/dev/client.js
@@ -9,6 +9,7 @@
     const enemies = {};
     const bullets = {};
     const obstacles = {};
+    const items = {};
 
     const addPlayer = playerInfo => {
       const player = kontra.Sprite({
@@ -77,6 +78,23 @@
       obstacles[obstacle.id] = obstacle;
     };
 
+    const addItem = itemInfo => {
+      const item = kontra.Sprite({
+        type: 'item',
+        id: itemInfo.id,
+        x: itemInfo.x,
+        y: itemInfo.y,
+        width: itemInfo.width,
+        height: itemInfo.height,
+        color: itemInfo.color,
+        render() {
+          this.context.fillStyle = this.color;
+          this.context.fillRect(this.x, this.y, this.width, this.height);
+        },
+      });
+      items[item.id] = item;
+    };
+
     /**
      * Client module init
      */
@@ -110,6 +128,9 @@
         for (let i = 0; i < data.obstacles.length; i++) {
           addObstacle(data.obstacles[i]);
         }
+        for (let i = 0; i < data.items.length; i++) {
+          addItem(data.items[i]);
+        }
       });
 
       socket.on('update', data => {
@@ -140,6 +161,12 @@
           obstacles[obstacle.id].x = obstacle.x;
           obstacles[obstacle.id].y = obstacle.y;
         }
+        const itemsData = data.items;
+        for (let i = 0; i < itemsData.length; i++) {
+          let item = itemsData[i];
+          items[item.id].x = item.x;
+          items[item.id].y = item.y;
+        }
       });
 
       socket.on('remove', data => {
@@ -154,6 +181,9 @@
         }
         for (let i = 0; i < data.obstacles.length; i++) {
           delete obstacles[data.obstacles[i]];
+        }
+        for (let i = 0; i < data.items.length; i++) {
+          delete items[data.items[i]];
         }
       });
 
@@ -184,6 +214,10 @@
         for (let i in obstacles) {
           const obstacle = obstacles[i];
           obstacle.render();
+        }
+        for (let i in items) {
+          const item = items[i];
+          item.render();
         }
         window.requestAnimationFrame(renderLoop);
       };

--- a/dev/lib/entities/bullet.js
+++ b/dev/lib/entities/bullet.js
@@ -13,7 +13,7 @@ class Bullet extends Entity {
     this.speedX = Math.cos((this.angle / 180) * Math.PI) * parent.weapon.speed;
     this.speedY = Math.sin((this.angle / 180) * Math.PI) * parent.weapon.speed;
     this.timer = 0;
-    this.damage = parent.weapon.damage; // comes from the Player, based on weapon
+    this.damage = parent.weapon.damage;
     this.toRemove = false;
 
     GAMES[this.gameId].bullets[this.id] = this;

--- a/dev/lib/game.js
+++ b/dev/lib/game.js
@@ -2,14 +2,17 @@ class Game {
     constructor() {
       this.id = generateId();
       this.room = `room-${this.id}`;
-      this.initPack = { players: [], enemies: [], bullets: [], obstacles: [] };
-      this.removePack = { players: [], enemies: [], bullets: [], obstacles: [] };
+      this.initPack =   { players: [], enemies: [], bullets: [],
+                          obstacles: [], items: [] };
+      this.removePack = { players: [], enemies: [], bullets: [],
+                          obstacles: [], items: [] };
       this.updatePack = {};
 
       this.players = {};
       this.bullets = {};
       this.obstacles = {};
       this.enemies = {};
+      this.items = {};
 
       // Moved from Enemy class, since this will vary by game
       // Chance starts at once per 5 seconds
@@ -70,6 +73,7 @@ class Game {
     'enemies': Enemy,
     'bullets': Bullet,
     'obstacles': Obstacle,
+    'items': Item,
   };
 
   /* Not using module.exports because require() is unavailable in the sandbox environment */

--- a/dev/lib/items.js
+++ b/dev/lib/items.js
@@ -1,0 +1,79 @@
+class Item extends Entity {
+    constructor(config) {
+        super();
+        this.id = generateId(); // TODO: will need to do something more unique
+        this.gameId = config.gameId;
+        this.x = config.x;
+        this.y = config.y;
+        this.name = config.name;
+        this.color = Weapon.weapons[this.name].color;
+        this.width = 15;
+        this.height = 15;
+        this.toRemove = false;
+        this.speedY = -1; // TODO: camera speed should be global for all entities
+
+        GAMES[this.gameId].items[this.id] = this;
+        GAMES[this.gameId].initPack.items.push(this.getInitPack());
+    }
+    update() {
+        if (this.y < -this.height - 5) {
+            // Remove items that go offscreen
+            this.toRemove = true;
+        }
+        super.update();
+        const game = GAMES[this.gameId];
+
+        // TODO: consider quadtree type structure for collisions
+        /* Collisions with players */
+        for (let id in game.players) {
+            let player = game.players[id];
+            if (Entity.overlaps(this, player)) {
+                this.toRemove = true;
+                // transform into weapon on pickup
+                const convertedToWeapon = new Weapon(this.name, player);
+                // if the player already has this weapon, just add ammo
+                if (player.weapon.name === this.name) {
+                    player.weapon.ammo += convertedToWeapon.ammo;
+                } else {
+                    player.weapon = convertedToWeapon;
+                }
+            }
+        }
+      }
+      getInitPack() {
+        return {
+          id: this.id,
+          x: this.x,
+          y: this.y,
+          width: this.width,
+          height: this.height,
+          color: this.color,
+          name: this.name,
+        };
+      }
+      getUpdatePack() {
+        return {
+          id: this.id,
+          x: this.x,
+          y: this.y,
+        };
+      }
+      static updateAll(gameId) {
+        const pack = [];
+        const game = GAMES[gameId];
+        for (let id in game.items) {
+          let item = game.items[id];
+          item.update();
+          if (item.toRemove) {
+            delete game.items[id];
+            game.removePack.items.push(item.id);
+          } else {
+            pack.push(item.getUpdatePack());
+          }
+        }
+        return pack;
+      }
+}
+
+/* Not using module.exports because require() is unavailable
+in the sandbox environment */

--- a/dev/lib/util.js
+++ b/dev/lib/util.js
@@ -16,4 +16,23 @@ function numIds(object) {
   return ids(object).length;
 }
 
+function getWeightedRandomItem(options) {
+  // expects options = [ { name: 'itemA', chance: 0.25 }, ...  ]
+  const random = Math.random();
+  let cumulativeChance = 0;
+  // options.forEach(option => {
+  //   cumulativeChance += option.chance;
+  //   if (random < cumulativeChance) {
+  //     return option.name;
+  //   }
+  // });
+  for (let i = 0; i < options.length; i++) {
+    const option = options[i];
+    cumulativeChance += option.chance;
+    if (random < cumulativeChance) {
+      return option.name;
+    }
+  }
+}
+
 /* Not using module.exports because require() is unavailable in the sandbox environment */

--- a/dev/lib/weapons.js
+++ b/dev/lib/weapons.js
@@ -1,0 +1,104 @@
+class Weapon {
+    constructor(name, parent) {
+        this.name = name;
+        this.parent = parent;
+        const weapon = Weapon.weapons[name];
+        for (let key in weapon) {
+            this[key] = weapon[key];
+        }
+    }
+    ableToShoot() {
+        const currentTime = new Date().getTime();
+        const timeSinceShot = currentTime - this.timeLastShot;
+        const isCool = timeSinceShot > this.coolDown;
+        const hasAmmo = this.ammo > 0;
+        return isCool && hasAmmo;
+    }
+    attemptShoot(angle) {
+        if (this.ableToShoot()) {
+            this.shootFunction(angle, this);
+        }
+    }
+    decrementAmmo() {
+        /* Only decrement ammo for player. This serves two purposes
+        1. Enemies have infinite ammo
+        2. Dropped guns will always have the expected amount of ammo */
+        if (this.parent.type === 'player') {
+            this.ammo -= 1;
+        }
+    }
+
+    /* Functions for shooting different guns */
+    static basicShoot(angle, weapon) {
+        if (weapon.ableToShoot()) {
+            new Bullet({
+                angle: angle,
+                parent: weapon.parent,
+            });
+            weapon.decrementAmmo();
+            weapon.timeLastShot = new Date().getTime();
+        }
+    }
+    static spreadShot(angle, weapon) {
+        if (weapon.ableToShoot()) {
+            const offsets = [-10, -5, 0, 5, 10];
+            offsets.forEach(offset => {
+                new Bullet({
+                    angle: angle + offset,
+                    parent: weapon.parent,
+                });
+            });
+            weapon.decrementAmmo();
+            weapon.timeLastShot = new Date().getTime();
+        }
+    }
+}
+Weapon.weapons = {
+    /*
+    - "coolDown" property is milliseconds, indepedent of FPS
+    - Number.MAX_SAFE_INTEGER is effectively infinite ammo
+    */
+
+    // default player gun, has inf ammo
+    'pistol': {
+        damage: 10,
+        speed: 30,
+        timeLastShot: 0,
+        coolDown: 400,
+        ammo: Number.MAX_SAFE_INTEGER,
+        shootFunction: Weapon.basicShoot,
+        dropable: false,
+    },
+    // default enemy gun, shoots slow
+    'slowpoke': {
+        damage: 10,
+        speed: 10,
+        timeLastShot: 0,
+        coolDown: 400,
+        ammo: 1, // not dropable, so just a placeholder
+        shootFunction: Weapon.basicShoot,
+        dropable: false,
+    },
+    'chaingun': {
+        damage: 10,
+        speed: 30,
+        timeLastShot: 0,
+        coolDown: 40,
+        ammo: 100,
+        shootFunction: Weapon.basicShoot,
+        dropable: true,
+        color: 'red',
+    },
+    'shotgun': {
+        damage: 20,
+        speed: 30,
+        timeLastShot: 0,
+        coolDown: 800,
+        ammo: 20,
+        shootFunction: Weapon.spreadShot,
+        dropable: true,
+        color: 'blue',
+    }
+};
+
+/* Not using module.exports because require() is unavailable in the sandbox environment */

--- a/dev/server.js
+++ b/dev/server.js
@@ -11,6 +11,8 @@ const FPS = 25
 //=require lib/util.js
 //=require lib/entity.js
 //=require lib/entities/*.js
+//=require lib/weapons.js
+//=require lib/items.js
 //=require lib/game.js
 
 // Game loop


### PR DESCRIPTION
This commit
 * refactors enemy weapons to use cooldown like players
* implements a Weapon class, and defines some new weapons
    * also adds an ammo mechanic
        * players consume ammo, enemies do not (this allows dropable
            weapons to maintain their default ammo, see below)
    * shooting logic is abstracted from player/enemy class to weapon class
* allows enemies to spawn with (weighted) random weapons
* implements an Item class, representing dropabble weapons
    * enemies with dropable weapons drop them on death
    * players can collect dropped weapons
        * new weapons replace players default weapon
        * if players already have the same weapon, the ammo is accumulated
        * if players run out of ammo, they return to their default weapon
    * dropped items are currently represented as colored boxes
    
new bug
* Enemies with chain guns shoot infrequently, since Enemy.chanceToShoot
    is lower than the fire rate of the chaingun. This could be fixed by subclassing
    enemies based on their weapon, and having individual enemy.chanceToShoot
    rates.