### PR TITLE
fix(enemy.js): fix enemy collision teleportation

### DIFF
--- a/dev/lib/entities/enemy.js
+++ b/dev/lib/entities/enemy.js
@@ -77,7 +77,7 @@ class Enemy extends Entity {
           this.x + this.speedX,
           this.y
         );
-        // set just the speed and not the position to avoid teleportation bug
+        // set just the speed and not the position to avoid teleportation bug (#30)
         if (collisionObject) {
           this.speedX = 0;
         }

--- a/dev/lib/entities/enemy.js
+++ b/dev/lib/entities/enemy.js
@@ -77,8 +77,8 @@ class Enemy extends Entity {
           this.x + this.speedX,
           this.y
         );
+        // set just the speed and not the position to avoid teleportation bug
         if (collisionObject) {
-          this.x = collisionObject.x - this.width;
           this.speedX = 0;
         }
         // enemy moving left
@@ -90,7 +90,6 @@ class Enemy extends Entity {
           this.y
         );
         if (collisionObject) {
-          this.x = collisionObject.x + collisionObject.width;
           this.speedX = 0;
         }
       } else {


### PR DESCRIPTION
Enemy x-collisions just set the speed to 0 and no longer update the enemy's position to the side of the obstacle. Because enemy's speed is 2px per frame they will stop at most 1px away from the side of the obstacle in an x-collision. May cause problems if we increase the enemy speed.