### PR TITLE
fix(gulp): remove duplicated files in build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,7 @@ const paths = {
         css: `dev/**/*.css`,
         js: `dev/**/*.js`,
         assets: `dev/assets/**`,
-        lib: `dev/lib/*`
+        lib: `dev/lib/**/*`
     },
     dist: {
         base: 'public',

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "serve": "npm run build && npm start"
   },
   "watch": {
-    "serve": "dev/*"
+    "serve": "dev/**/*"
   },
   "keywords": [
     "js13kgames",


### PR DESCRIPTION
Previously, nested lib/ files weren't being ignored by the gulp build
process and were being copied over (as duplicates). This commit
updates the build configuration to avoid this.